### PR TITLE
Add support for "global" tags that are added to all tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,32 @@ import com.yammer.metrics.reporting.DatadogReporter
 DatadogReporter.enable(15, TimeUnit.SECONDS, myDatadogKey)
 ~~~
 
+## Tags
+
+You may optionally specify tags for either individual metrics or globally
+to be applied to all metrics.  Tags may be simple strings (i.e. "foo") or
+name-value pairs (i.e. "foo:bar").
+
+### Metric Tags
+
+To tag a specific metric you use square brackets in the metrics name, like so:
+
+~~~
+test[tag1] // Tag only
+test[tag1:value1,tag2:value2,tag3] // Tag and value, multiple tags
+~~~
+
+Invalid characters will be stripped out.
+
+### Global Tags
+
+If you have global tags you'd like applied to all your metrics you can specify
+them when enabling, like so:
+
+~~~scala
+DatadogReporter.enable(15, TimeUnit.SECONDS, myDatadogKey, Arrays.asList("tag1", "tag2:value2"))
+~~~
+
 ## Maven
 
 This repo is subject to change. Nuts!

--- a/src/main/java/com/yammer/metrics/reporting/DatadogReporter.java
+++ b/src/main/java/com/yammer/metrics/reporting/DatadogReporter.java
@@ -234,7 +234,7 @@ public class DatadogReporter extends AbstractPollingReporter implements
   }
 
   private void pushCounter(String name, Long count, Long epoch) {
-    DatadogCounter counter = new DatadogCounter(name, count, epoch, host);
+    DatadogCounter counter = new DatadogCounter(name, count, epoch, host, tags);
     try {
       mapper.writeValue(jsonOut, counter);
     } catch (Exception e) {
@@ -252,7 +252,7 @@ public class DatadogReporter extends AbstractPollingReporter implements
   }
 
   private void sendGauge(String name, Number count, Long epoch) {
-    DatadogGauge gauge = new DatadogGauge(name, count, epoch, host);
+    DatadogGauge gauge = new DatadogGauge(name, count, epoch, host, tags);
     try {
       mapper.writeValue(jsonOut, gauge);
     } catch (Exception e) {

--- a/src/main/java/com/yammer/metrics/reporting/model/DatadogCounter.java
+++ b/src/main/java/com/yammer/metrics/reporting/model/DatadogCounter.java
@@ -1,9 +1,11 @@
 package com.yammer.metrics.reporting.model;
 
+import java.util.List;
+
 public class DatadogCounter extends DatadogSeries<Long> {
-  
-  public DatadogCounter(String name, Long count, Long epoch, String host) {
-    super(name, count, epoch, host);
+
+  public DatadogCounter(String name, Long count, Long epoch, String host, List<String> tags) {
+    super(name, count, epoch, host, tags);
   }
 
   public String getType() {

--- a/src/main/java/com/yammer/metrics/reporting/model/DatadogGauge.java
+++ b/src/main/java/com/yammer/metrics/reporting/model/DatadogGauge.java
@@ -1,11 +1,12 @@
 package com.yammer.metrics.reporting.model;
 
+import java.util.List;
 
 public class DatadogGauge extends DatadogSeries<Number> {
-  public DatadogGauge(String name, Number count, Long epoch, String host) {
-    super(name, count, epoch, host);
+  public DatadogGauge(String name, Number count, Long epoch, String host, List<String> tags) {
+    super(name, count, epoch, host, tags);
   }
-  
+
   public String getType() {
     return "gauge";
   }

--- a/src/main/java/com/yammer/metrics/reporting/model/DatadogSeries.java
+++ b/src/main/java/com/yammer/metrics/reporting/model/DatadogSeries.java
@@ -22,10 +22,14 @@ public abstract class DatadogSeries<T extends Number> {
   private final Pattern tagPattern = Pattern
       .compile("([\\w\\.]+)\\[([\\w\\W]+)\\]");
 
-  public DatadogSeries(String name, T count, Long epoch, String host) {
+  public DatadogSeries(String name, T count, Long epoch, String host, List<String> tags) {
     Matcher matcher = tagPattern.matcher(name);
-    this.tags = new ArrayList<String>();
-    
+    if(tags == null) {
+      this.tags = new ArrayList<String>();
+    } else {
+      this.tags = new ArrayList<String>(tags);
+    }
+
     if (matcher.find() && matcher.groupCount() == 2) {
       this.name = matcher.group(1);
       for(String t : matcher.group(2).split("\\,")) {
@@ -34,7 +38,7 @@ public abstract class DatadogSeries<T extends Number> {
     } else {
       this.name = name;
     }
-    
+
     this.count = count;
     this.epoch = epoch;
     this.host = host;

--- a/src/test/java/com/yammer/metrics/reporting/DatadogCounterTest.java
+++ b/src/test/java/com/yammer/metrics/reporting/DatadogCounterTest.java
@@ -2,6 +2,7 @@ package com.yammer.metrics.reporting;
 
 import static org.junit.Assert.*;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;
@@ -13,7 +14,7 @@ public class DatadogCounterTest {
   @Test
   public void testSplitNameAndTags() {
     DatadogCounter counter = new DatadogCounter(
-        "test[tag1:value1,tag2:value2,tag3:value3]", 1L, 1234L, "Test Host");
+        "test[tag1:value1,tag2:value2,tag3:value3]", 1L, 1234L, "Test Host", null);
     List<String> tags = counter.getTags();
 
     assertEquals(3, tags.size());
@@ -21,11 +22,11 @@ public class DatadogCounterTest {
     assertEquals("tag2:value2", tags.get(1));
     assertEquals("tag3:value3", tags.get(2));
   }
-  
+
   @Test
   public void testStripInvalidCharsFromTags() {
     DatadogCounter counter = new DatadogCounter(
-        "test[tag1:va  lue1,tag2:va .%lue2,ta  %# g3:value3]", 1L, 1234L, "Test Host");
+        "test[tag1:va  lue1,tag2:va .%lue2,ta  %# g3:value3]", 1L, 1234L, "Test Host", null);
     List<String> tags = counter.getTags();
 
     assertEquals(3, tags.size());
@@ -33,5 +34,15 @@ public class DatadogCounterTest {
     assertEquals("tag2:value2", tags.get(1));
     assertEquals("tag3:value3", tags.get(2));
   }
-  
+
+  @Test
+  public void testGlobalTags() {
+    DatadogCounter counter = new DatadogCounter(
+        "test[tag1:value1]", 1L, 1234L, "Test Host", Arrays.asList("tag2:value2"));
+    List<String> tags = counter.getTags();
+
+    assertEquals(2, tags.size());
+    assertTrue(tags.contains("tag1:value1"));
+    assertTrue(tags.contains("tag2:value2"));
+  }
 }

--- a/src/test/java/com/yammer/metrics/reporting/DatadogGaugeTest.java
+++ b/src/test/java/com/yammer/metrics/reporting/DatadogGaugeTest.java
@@ -2,6 +2,7 @@ package com.yammer.metrics.reporting;
 
 import static org.junit.Assert.*;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;
@@ -13,7 +14,7 @@ public class DatadogGaugeTest {
   @Test
   public void testSplitNameAndTags() {
     DatadogGauge gauge = new DatadogGauge(
-        "test[tag1:value1,tag2:value2,tag3:value3]", 1L, 1234L, "Test Host");
+        "test[tag1:value1,tag2:value2,tag3:value3]", 1L, 1234L, "Test Host", null);
     List<String> tags = gauge.getTags();
 
     assertEquals(3, tags.size());
@@ -26,13 +27,25 @@ public class DatadogGaugeTest {
   public void testStripInvalidCharsFromTags() {
     DatadogGauge gauge = new DatadogGauge(
         "test[tag1:va  lue1,tag2:va .%lue2,ta  %# g3:value3]", 1L, 1234L,
-        "Test Host");
+        "Test Host", null);
     List<String> tags = gauge.getTags();
 
     assertEquals(3, tags.size());
     assertEquals("tag1:value1", tags.get(0));
     assertEquals("tag2:value2", tags.get(1));
     assertEquals("tag3:value3", tags.get(2));
+  }
+
+  @Test
+  public void testGlobalTags() {
+    DatadogGauge gauge = new DatadogGauge(
+        "test[tag1:value1]", 1L, 1234L,
+        "Test Host", Arrays.asList("tag2:value2"));
+    List<String> tags = gauge.getTags();
+
+    assertEquals(2, tags.size());
+    assertTrue(tags.contains("tag1:value1"));
+    assertTrue(tags.contains("tag2:value2"));
   }
 
 }

--- a/src/test/java/com/yammer/metrics/reporting/DatadogReporterTest.java
+++ b/src/test/java/com/yammer/metrics/reporting/DatadogReporterTest.java
@@ -41,11 +41,11 @@ public class DatadogReporterTest {
     vm = VirtualMachineMetrics.getInstance();
     ddNoHost = new DatadogReporter(metricsRegistry, MetricPredicate.ALL,
         VirtualMachineMetrics.getInstance(), transport, Clock.defaultClock(),
-        null);
+        null, null);
 
     dd = new DatadogReporter(metricsRegistry, MetricPredicate.ALL,
         VirtualMachineMetrics.getInstance(), transport, Clock.defaultClock(),
-        "hostname");
+        "hostname", null);
   }
 
   @SuppressWarnings("unchecked")
@@ -123,7 +123,7 @@ public class DatadogReporterTest {
     Meter s = metricsRegistry.newMeter(String.class,
         "meter[with,tags]", "ticks", TimeUnit.SECONDS);
     s.mark();
-    
+
     ddNoHost.printVmMetrics = false;
     ddNoHost.run();
     String body = new String(transport.lastRequest.getPostBody(), "UTF-8");
@@ -131,12 +131,12 @@ public class DatadogReporterTest {
     Map<String, Object> request = new ObjectMapper().readValue(body,
         HashMap.class);
     List<Object> series = (List<Object>) request.get("series");
-    
+
     for(Object o : series) {
       HashMap<String, Object> rec = (HashMap<String, Object>) o;
       List<String> tags = (List<String>) rec.get("tags");
       String name = rec.get("metric").toString();
-      
+
       assertTrue(name.startsWith("java.lang.String.meter"));
       assertEquals("with", tags.get(0));
       assertEquals("tags", tags.get(1));

--- a/src/test/java/com/yammer/metrics/reporting/DatadogReporterTest.java
+++ b/src/test/java/com/yammer/metrics/reporting/DatadogReporterTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +30,7 @@ public class DatadogReporterTest {
   MockTransport transport;
   VirtualMachineMetrics vm;
   Clock clock;
+  DatadogReporter ddGlobalTags;
   DatadogReporter ddNoHost;
   DatadogReporter dd;
   static final MetricPredicate ALL = MetricPredicate.ALL;
@@ -46,6 +48,10 @@ public class DatadogReporterTest {
     dd = new DatadogReporter(metricsRegistry, MetricPredicate.ALL,
         VirtualMachineMetrics.getInstance(), transport, Clock.defaultClock(),
         "hostname", null);
+
+    ddGlobalTags = new DatadogReporter(metricsRegistry, MetricPredicate.ALL,
+        VirtualMachineMetrics.getInstance(), transport, Clock.defaultClock(),
+        "hostname", Arrays.asList("tag1", "tag2:value2"));
   }
 
   @SuppressWarnings("unchecked")
@@ -140,6 +146,34 @@ public class DatadogReporterTest {
       assertTrue(name.startsWith("java.lang.String.meter"));
       assertEquals("with", tags.get(0));
       assertEquals("tags", tags.get(1));
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testTaggedMeterWithGlobal() throws Throwable {
+    Meter s = metricsRegistry.newMeter(String.class,
+        "meter[with,tags]", "ticks", TimeUnit.SECONDS);
+    s.mark();
+
+    ddGlobalTags.printVmMetrics = false;
+    ddGlobalTags.run();
+    String body = new String(transport.lastRequest.getPostBody(), "UTF-8");
+
+    Map<String, Object> request = new ObjectMapper().readValue(body,
+        HashMap.class);
+    List<Object> series = (List<Object>) request.get("series");
+
+    for(Object o : series) {
+      HashMap<String, Object> rec = (HashMap<String, Object>) o;
+      List<String> tags = (List<String>) rec.get("tags");
+      String name = rec.get("metric").toString();
+
+      assertTrue(name.startsWith("java.lang.String.meter"));
+      assertTrue(tags.contains("with"));
+      assertTrue(tags.contains("tags"));
+      assertTrue(tags.contains("tag1"));
+      assertTrue(tags.contains("tag2:value2"));
     }
   }
 }


### PR DESCRIPTION
This change adds another (optional) argument to `enable()` that allows the user to provide a list of tags that will be included with all metrics sent to Datadog. I foresee using this with things like application versions or names!

I also included documentation for the existing tag support. I believe I read the source right so that I could explain it. Thanks and let me know if I can help to get this merged by making any changes.  Thanks for making this!
